### PR TITLE
Fix messaging system bug

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -150,5 +150,7 @@
                 }
             });
         </script>
+
+        @stack('scripts')
     </body>
 </html>

--- a/resources/views/messages/index.blade.php
+++ b/resources/views/messages/index.blade.php
@@ -48,7 +48,7 @@
                                                     </h3>
                                                     @if($lastMessage)
                                                         <p class="text-sm text-gray-600 dark:text-gray-400 truncate">
-                                                            {{ Str::limit($lastMessage->body, 50) }}
+                                                            {{ \Illuminate\Support\Str::limit($lastMessage->body, 50) }}
                                                         </p>
                                                     @endif
                                                 </div>

--- a/resources/views/messages/show.blade.php
+++ b/resources/views/messages/show.blade.php
@@ -65,7 +65,7 @@
                                         <span class="text-xs opacity-75">{{ $message->sender->name }}</span>
                                         <span class="text-xs opacity-75">{{ $message->created_at->format('H:i') }}</span>
                                     </div>
-                                    <p class="text-sm">{{ $message->body }}</p>
+                                    <p class="text-sm">{!! nl2br(e($message->body)) !!}</p>
                                 </div>
                             </div>
                         @endforeach


### PR DESCRIPTION
Add scripts stack, fix `Str` class usage, and preserve message line breaks to resolve display and script loading issues in the messaging feature.

---
<a href="https://cursor.com/background-agent?bcId=bc-4a1250c1-1848-4984-9cd6-dce31e8274dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4a1250c1-1848-4984-9cd6-dce31e8274dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

